### PR TITLE
SONARRUBY-20 Fix FP on ruby:S1481 (unused local variable) when facing `case` syntax

### DIFF
--- a/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/converter/RubyVisitor.java
+++ b/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/converter/RubyVisitor.java
@@ -556,11 +556,16 @@ public class RubyVisitor {
   }
 
   private Tree createCaseTree(AstNode node, List<?> children) {
-    Tree expression = ((Tree) children.get(0));
-    Tree body = ((Tree) children.get(1));
+    int bodyIndex = children.size() - 1;
+
+    var expressionItems = children.subList(0, bodyIndex);
+    Tree expression = createNativeTree(node, expressionItems);
+
+    Tree body = (Tree) children.get(bodyIndex);
     if (body == null) {
       body = new BlockTreeImpl(metaData(node), Collections.emptyList());
     }
+
     return new MatchCaseTreeImpl(metaData(node), expression, body);
   }
 

--- a/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/converter/visitor/CaseVisitorTest.java
+++ b/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/converter/visitor/CaseVisitorTest.java
@@ -91,4 +91,51 @@ class CaseVisitorTest extends AbstractRubyConverterTest {
     assertThat(tree.cases().get(1).body()).isNotNull();
   }
 
+  @Test
+  void case_when_multiple() {
+    MatchTree tree = (MatchTree) rubyStatement(
+            "case x\n " +
+            "when 1, 7\n " +
+            "  doSomething()\n" +
+            "  doManyThings()\n" +
+            "else doSomethingElse()\n" +
+            "end");
+
+    assertThat(tree.keyword().text()).isEqualTo("case");
+    assertTree(tree.expression()).isEquivalentTo(sendToIdentifier("x"));
+    assertThat(tree.cases()).hasSize(2);
+    MatchCaseTree matchCase0 = tree.cases().get(0);
+    assertThat(matchCase0.expression()).isNotNull();
+    assertTree(matchCase0.body()).isBlock(NativeTree.class, NativeTree.class);
+    assertTree(matchCase0.body()).hasTextRange(3, 3, 4, 16);
+    assertRange(matchCase0.rangeToHighlight()).hasRange(2, 1, 2, 10);
+
+    MatchCaseTree elseMatchCase = tree.cases().get(1);
+    assertThat(elseMatchCase.expression()).isNull();
+    assertThat(elseMatchCase.body()).isNotNull();
+    assertRange(elseMatchCase.rangeToHighlight()).hasRange(5, 0, 5, 4);
+  }
+
+  @Test
+  void case_when_multiple_and_empty_body() {
+    MatchTree tree = (MatchTree) rubyStatement(
+            "case x\n " +
+            "when 1, 7\n " +
+            "else doSomethingElse()\n" +
+            "end");
+
+    assertThat(tree.keyword().text()).isEqualTo("case");
+    assertTree(tree.expression()).isEquivalentTo(sendToIdentifier("x"));
+    assertThat(tree.cases()).hasSize(2);
+    MatchCaseTree matchCase0 = tree.cases().get(0);
+    assertThat(matchCase0.expression()).isNotNull();
+    assertTree(matchCase0.body()).isBlock();
+    assertTree(matchCase0.body()).hasTextRange(2,1,2,10);
+    assertRange(matchCase0.rangeToHighlight()).hasRange(2, 1, 2, 10);
+
+    MatchCaseTree elseMatchCase = tree.cases().get(1);
+    assertThat(elseMatchCase.expression()).isNull();
+    assertThat(elseMatchCase.body()).isNotNull();
+    assertRange(elseMatchCase.rangeToHighlight()).hasRange(3,1,3,5);
+  }
 }

--- a/sonar-ruby-plugin/src/test/resources/checks/UnusedLocalVariable.rb
+++ b/sonar-ruby-plugin/src/test/resources/checks/UnusedLocalVariable.rb
@@ -74,3 +74,12 @@ def nested_inside()
         nested_not_used = 2 # Noncompliant
     end
 end
+
+def with_case_statement
+     x = 9000 # Compliant, used below
+
+    case 4
+    when 1, 4
+       return x
+    end
+end


### PR DESCRIPTION
[SONARRUBY-20](https://sonarsource.atlassian.net/browse/SONARRUBY-20)

The false positive occurs when there are multiple values in the expression. The previous code was assuming `children[0]` is the expression, and `children[1]` is the body. `chiildren[2..N]` were just ignored, so if 2..N contained the only reference to a local variable, the analyzer would incorrectly flag that local variable as unused.

The fix is to consider the body to be the last child, and the expression is all children other than the last.

The format of `children` as a flat array of expression and body [appears to be intended functionality by the whitequark parser](https://github.com/whitequark/parser/blob/4d718c044ba02b2ae741969bc8055387999b8600/test/test_parser.rb#L4999-L5006)

[SONARRUBY-20]: https://sonarsource.atlassian.net/browse/SONARRUBY-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ