### PR TITLE
SONARRUBY-20: fix integration tests

### DIFF
--- a/its/ruling/src/test/resources/expected/ruby/ruby-S1172.json
+++ b/its/ruling/src/test/resources/expected/ruby/ruby-S1172.json
@@ -80,9 +80,6 @@
 'ruby-project:sources/ruby/rails/actionpack/test/dispatch/session/abstract_store_test.rb':[
 52,
 ],
-'ruby-project:sources/ruby/rails/actionview/lib/action_view/helpers/form_helper.rb':[
-1550,
-],
 'ruby-project:sources/ruby/rails/actionview/lib/action_view/helpers/number_helper.rb':[
 427,
 ],
@@ -181,9 +178,6 @@
 712,
 743,
 743,
-],
-'ruby-project:sources/ruby/rails/activerecord/lib/active_record/relation/where_clause.rb':[
-137,
 ],
 'ruby-project:sources/ruby/rails/activerecord/lib/active_record/schema_dumper.rb':[
 92,

--- a/its/ruling/src/test/resources/expected/ruby/ruby-S1192.json
+++ b/its/ruling/src/test/resources/expected/ruby/ruby-S1192.json
@@ -1151,6 +1151,9 @@
 'ruby-project:sources/ruby/jekyll/lib/jekyll/commands/serve/live_reload_reactor.rb':[
 77,
 ],
+'ruby-project:sources/ruby/jekyll/lib/jekyll/utils.rb':[
+261,
+],
 'ruby-project:sources/ruby/jekyll/test/test_cleaner.rb':[
 10,
 11,

--- a/its/ruling/src/test/resources/expected/ruby/ruby-S134.json
+++ b/its/ruling/src/test/resources/expected/ruby/ruby-S134.json
@@ -36,6 +36,9 @@
 686,
 993,
 ],
+'ruby-project:sources/ruby/rails/activerecord/lib/active_record/relation/predicate_builder.rb':[
+81,
+],
 'ruby-project:sources/ruby/rails/activerecord/test/cases/transactions_test.rb':[
 493,
 ],


### PR DESCRIPTION
[SONARRUBY-20](https://sonarsource.atlassian.net/browse/SONARRUBY-20)

#35 caused the integration tests to break. This PR fixes the integration tests. I have reviewed the removed and newly added issues. They are accurate and make sense with the new change. The change caused the body of these case statements to now be parsed, which removed some False Positives on S1172 and added some True Positives on S1192 and S134.


[SONARRUBY-20]: https://sonarsource.atlassian.net/browse/SONARRUBY-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ