### PR TITLE
SONARRUBY-49 Fix discrepancies between MQR and severity for Ruby rules

### DIFF
--- a/sonar-ruby-plugin/sonarpedia.json
+++ b/sonar-ruby-plugin/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "RUBY"
   ],
-  "latest-update": "2024-11-28T14:46:38.056875528Z",
+  "latest-update": "2025-02-27T12:17:33.380172761Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true

--- a/sonar-ruby-plugin/src/main/resources/org/sonar/l10n/ruby/rules/ruby/S1135.json
+++ b/sonar-ruby-plugin/src/main/resources/org/sonar/l10n/ruby/rules/ruby/S1135.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "INFO"
     },
     "attribute": "COMPLETE"
   },


### PR DESCRIPTION
[SONARRUBY-49](https://sonarsource.atlassian.net/browse/SONARRUBY-49)



[SONARRUBY-49]: https://sonarsource.atlassian.net/browse/SONARRUBY-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ