### PR TITLE
SONARRUBY-68 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/plugin/src/test/java/org/sonarsource/slang/TestBase.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/TestBase.java
@@ -51,6 +51,7 @@ public abstract class TestBase {
       ORCHESTRATOR.getServer().associateProjectToQualityProfile(projectKey, languageKey, profileName);
     }
     return SonarScanner.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectDir(new File(directoryToScan, languageKey))
       .setProjectKey(projectKey)
       .setProjectName(projectKey)

--- a/its/ruling/src/test/java/org/sonarsource/slang/SlangRulingTest.java
+++ b/its/ruling/src/test/java/org/sonarsource/slang/SlangRulingTest.java
@@ -116,6 +116,7 @@ public class SlangRulingTest {
 
     File litsDifferencesFile = FileLocation.of("build/" + projectKey + "-differences").getFile();
     SonarScanner build = SonarScanner.create(FileLocation.of("../").getFile())
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1")


### PR DESCRIPTION
[SONARRUBY-68](https://sonarsource.atlassian.net/browse/SONARRUBY-68)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.

[SONARRUBY-68]: https://sonarsource.atlassian.net/browse/SONARRUBY-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ