### PR TITLE
SONARRUBY-69 Migrate Gradle wrapper to version 7.6.5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,12 +29,6 @@ linux_2_cpu_4G_template: &LINUX_2_CPU_4G
     cpu: 2
     memory: 4G
 
-linux_4_cpu_6G_java_17_template: &LINUX_4_CPU_6G_JAVA_17
-  eks_container:
-    <<: *LINUX_IMAGE
-    cpu: 4
-    memory: 6G
-
 linux_4_cpu_8G_java_17_template: &LINUX_4_CPU_8G_JAVA_17
   eks_container:
     <<: *LINUX_IMAGE
@@ -122,7 +116,7 @@ qa_plugin_task:
     matrix:
       - SQ_VERSION: "DEV"
       - SQ_VERSION: "LATEST_RELEASE"
-  <<: *LINUX_4_CPU_6G_JAVA_17
+  <<: *LINUX_4_CPU_8G_JAVA_17
   <<: *GRADLE_ITS_TEMPLATE
 
 qa_ruling_task:

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import java.util.jar.JarInputStream
 plugins {
     id 'java'
     id 'jacoco'
-    id 'com.jfrog.artifactory' version '4.28.2'
+    id 'com.jfrog.artifactory' version '5.2.5'
     id 'org.sonarqube' version '3.5.0.2730'
     id 'de.thetaphi.forbiddenapis' version '3.0' apply false
     id 'com.diffplug.spotless' version '6.15.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
[SONARRUBY-69](https://sonarsource.atlassian.net/browse/SONARRUBY-69)



[SONARRUBY-69]: https://sonarsource.atlassian.net/browse/SONARRUBY-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ