### PR TITLE
SONARRUBY-76 Migrate QA plugin task from Cirrus to Github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,18 +36,26 @@ jobs:
           artifactory-reader-role: private-reader    # Override for public repo using private access
           artifactory-deployer-role: qa-deployer     # Override for public repo using private access
 
-  qa_plugin:
+  qa:
     needs: [build]
     runs-on: github-ubuntu-latest-s  # Public repository runner
-    name: QA Plugin Tests
+    name: QA Tests
     permissions:
       id-token: write  # Required for Vault OIDC authentication
       contents: write  # Required for repository access
     strategy:
       matrix:
-        sq_version: [DEV, LATEST_RELEASE]
+        # Plugin tests check API compatibility, so they should run against all supported versions.
+        # Ruling tests check only that the results of analysis have not changed,
+        # so one sonar.runtimeVersion is enough.
+        item:
+          - { suite: "plugin", sq_version: "DEV", submodules: false}
+          - { suite: "plugin", sq_version: "LATEST_RELEASE", submodules: false}
+          - { suite: "ruling", sq_version: "LATEST_RELEASE", submodules: true}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: ${{ matrix.item.submodules }}
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           version: 2025.7.12
@@ -58,51 +66,16 @@ jobs:
           secrets: |
             development/github/token/licenses-ro token | GITHUB_TOKEN;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-      - name: Run QA Plugin Tests
+      - name: Run QA Tests
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-          SQ_VERSION: ${{ matrix.sq_version }}
+          SUITE: ${{ matrix.item.suite }}
+          SQ_VERSION: ${{ matrix.item.sq_version }}
           BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
         run: |
-          ./gradlew ":its:plugin:test" "-Pplugin" \
+          ./gradlew ":its:${SUITE}:test" "-P${SUITE}" \
             "-Dsonar.runtimeVersion=${SQ_VERSION}" \
-            "-Dorchestrator.artifactory.accessToken=${ARTIFACTORY_ACCESS_TOKEN}" \
-            "-DbuildNumber=${BUILD_NUMBER}" \
-            -Pqa --info --stacktrace --console plain --no-daemon --build-cache
-
-  qa_ruling:
-    needs: [build]
-    runs-on: github-ubuntu-latest-s  # Public repository runner
-    name: QA Ruling Tests
-    permissions:
-      id-token: write  # Required for Vault OIDC authentication
-      contents: write  # Required for repository access
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          submodules: true
-      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
-        with:
-          version: 2025.7.12
-      - name: Get Vault secrets
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/github/token/licenses-ro token | GITHUB_TOKEN;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-      - name: Run QA Plugin Tests
-        env:
-          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-          BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
-          # Ruling tests only that the results of analysis have not changed,
-          # so one sonar.runtimeVersion is enough.
-          # Plugin tests check API compatibility, so they should run against all supported versions.
-        run: |
-          ./gradlew ":its:ruling:test" "-Pruling" \
-            "-Dsonar.runtimeVersion=LATEST_RELEASE" \
             "-Dorchestrator.artifactory.accessToken=${ARTIFACTORY_ACCESS_TOKEN}" \
             "-DbuildNumber=${BUILD_NUMBER}" \
             -Pqa --info --stacktrace --console plain --no-daemon --build-cache
@@ -110,8 +83,7 @@ jobs:
   promote:
     needs:
       - build
-      - qa_plugin
-      - qa_ruling
+      - qa
     runs-on: github-ubuntu-latest-s  # Public repository runner
     name: Promote
     permissions:


### PR DESCRIPTION
[SONARRUBY-76](https://sonarsource.atlassian.net/browse/SONARRUBY-76)



[SONARRUBY-76]: https://sonarsource.atlassian.net/browse/SONARRUBY-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ