### PR TITLE
DO NOT MERGE Default Ruby sensor skip flag to true

### DIFF
--- a/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/RubyPlugin.java
+++ b/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/RubyPlugin.java
@@ -17,6 +17,7 @@
 package org.sonarsource.ruby.plugin;
 
 import org.sonar.api.Plugin;
+import org.sonar.api.PropertyType;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinition.ConfigScope;
@@ -60,6 +61,16 @@ public class RubyPlugin implements Plugin {
         RuboCopRulesDefinition.class,
         RuboCopSensor.class,
         SimpleCovSensor.class,
+
+        PropertyDefinition.builder(RubySensor.SKIP_PROPERTY_KEY)
+          .defaultValue("true")
+          .name("Internal: Skip Ruby Sensor")
+          .description("Internal property to disable the Ruby sensor. Set to false to re-enable Ruby analysis.")
+          .type(PropertyType.BOOLEAN)
+          .category(RUBY_CATEGORY)
+          .subCategory(GENERAL)
+          .onlyOnConfigScopes(ConfigScope.PROJECT)
+          .build(),
 
         PropertyDefinition.builder(RUBY_FILE_SUFFIXES_KEY)
           .defaultValue(RUBY_FILE_SUFFIXES_DEFAULT_VALUE)

--- a/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/RubySensor.java
+++ b/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/RubySensor.java
@@ -75,7 +75,7 @@ public class RubySensor extends SlangSensor {
   }
 
   private static boolean shouldSkip(Configuration configuration) {
-    return configuration.getBoolean(SKIP_PROPERTY_KEY).orElse(false);
+    return configuration.getBoolean(SKIP_PROPERTY_KEY).orElse(true);
   }
 
 }

--- a/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/RubySensor.java
+++ b/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/RubySensor.java
@@ -16,10 +16,14 @@
  */
 package org.sonarsource.ruby.plugin;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.Checks;
 import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonarsource.ruby.converter.RubyConverter;
@@ -29,12 +33,30 @@ import org.sonarsource.slang.plugin.SlangSensor;
 
 public class RubySensor extends SlangSensor {
 
+  private static final Logger LOG = LoggerFactory.getLogger(RubySensor.class);
+  public static final String SKIP_PROPERTY_KEY = "sonar.ruby.internal.skipRubySensor";
+
   private final Checks<SlangCheck> checks;
 
   public RubySensor(SonarRuntime sonarRuntime, CheckFactory checkFactory, FileLinesContextFactory fileLinesContextFactory, NoSonarFilter noSonarFilter, RubyLanguage language) {
     super(sonarRuntime, noSonarFilter, fileLinesContextFactory, language);
     checks = checkFactory.create(RubyPlugin.RUBY_REPOSITORY_KEY);
     checks.addAnnotatedChecks((Iterable<?>) RubyCheckList.checks());
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
+    super.describe(descriptor);
+    descriptor.onlyWhenConfiguration(configuration -> !shouldSkip(configuration));
+  }
+
+  @Override
+  public void execute(SensorContext context) {
+    if (shouldSkip(context.config())) {
+      LOG.info("Skipping Ruby sensor because '{}' is enabled.", SKIP_PROPERTY_KEY);
+      return;
+    }
+    super.execute(context);
   }
 
   @Override
@@ -50,6 +72,10 @@ public class RubySensor extends SlangSensor {
   @Override
   protected String repositoryKey() {
     return RubyPlugin.RUBY_REPOSITORY_KEY;
+  }
+
+  private static boolean shouldSkip(Configuration configuration) {
+    return configuration.getBoolean(SKIP_PROPERTY_KEY).orElse(false);
   }
 
 }

--- a/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/RubyPluginTest.java
+++ b/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/RubyPluginTest.java
@@ -21,6 +21,7 @@ import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
+import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.internal.PluginContextImpl;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
@@ -34,7 +35,14 @@ class RubyPluginTest {
     SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
     Plugin.Context context = new Plugin.Context(runtime);
     new RubyPlugin().define(context);
-    assertThat(context.getExtensions()).hasSize(12);
+    assertThat(context.getExtensions()).hasSize(13);
+    assertThat(context.getExtensions())
+      .filteredOn(PropertyDefinition.class::isInstance)
+      .anySatisfy(extension -> {
+        PropertyDefinition propertyDefinition = (PropertyDefinition) extension;
+        assertThat(propertyDefinition.key()).isEqualTo(RubySensor.SKIP_PROPERTY_KEY);
+        assertThat(propertyDefinition.defaultValue()).isEqualTo("true");
+      });
   }
 
   @Test

--- a/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/RubySensorTest.java
+++ b/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/RubySensorTest.java
@@ -112,6 +112,20 @@ class RubySensorTest extends AbstractSensorTest {
     assertThat(logTester.logs()).contains(String.format("Unable to parse file: %s. Parse error at position 1:2", inputFile.uri()));
   }
 
+  @Test
+  void skip_sensor_when_internal_property_is_enabled() {
+    InputFile inputFile = createInputFile("file1.rb", "{ <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }");
+    context.fileSystem().add(inputFile);
+    context.setSettings(new MapSettings());
+    context.settings().setProperty(RubySensor.SKIP_PROPERTY_KEY, "true");
+
+    sensor(checkFactory("S1764")).execute(context);
+
+    assertThat(context.allAnalysisErrors()).isEmpty();
+    assertThat(context.highlightingTypeAt(inputFile.key(), 1, 0)).isEmpty();
+    assertThat(logTester.logs()).contains("Skipping Ruby sensor because 'sonar.ruby.internal.skipRubySensor' is enabled.");
+  }
+
 
   @Override
   protected String repositoryKey() {

--- a/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/RubySensorTest.java
+++ b/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/RubySensorTest.java
@@ -33,6 +33,7 @@ class RubySensorTest extends AbstractSensorTest {
 
   @Test
   void simple_file() {
+    setSkipProperty(false);
     InputFile inputFile = createInputFile("file1.rb", """
       class C
       end
@@ -50,6 +51,7 @@ class RubySensorTest extends AbstractSensorTest {
 
   @Test
   void test_access_modifiers_are_highlighted() {
+    setSkipProperty(false);
     String source = """
       class Foo
         def is_public_by_default()
@@ -95,6 +97,7 @@ class RubySensorTest extends AbstractSensorTest {
 
   @Test
   void test_fail_parsing() {
+    setSkipProperty(false);
     InputFile inputFile = createInputFile("file1.rb", "{ <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }");
     context.fileSystem().add(inputFile);
     CheckFactory checkFactory = checkFactory("S1764");
@@ -113,16 +116,29 @@ class RubySensorTest extends AbstractSensorTest {
   }
 
   @Test
+  void skip_sensor_by_default() {
+    InputFile inputFile = createInputFile("file1.rb", """
+      class C
+      end
+      puts '1 == 1'; puts 'abc'
+      """);
+    context.fileSystem().add(inputFile);
+
+    sensor(checkFactory()).execute(context);
+
+    assertThat(context.highlightingTypeAt(inputFile.key(), 1, 0)).isEmpty();
+    assertThat(logTester.logs()).contains("Skipping Ruby sensor because 'sonar.ruby.internal.skipRubySensor' is enabled.");
+  }
+
+  @Test
   void skip_sensor_when_internal_property_is_enabled() {
     InputFile inputFile = createInputFile("file1.rb", "{ <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }");
     context.fileSystem().add(inputFile);
-    context.setSettings(new MapSettings());
-    context.settings().setProperty(RubySensor.SKIP_PROPERTY_KEY, "true");
+    setSkipProperty(true);
 
     sensor(checkFactory("S1764")).execute(context);
 
     assertThat(context.allAnalysisErrors()).isEmpty();
-    assertThat(context.highlightingTypeAt(inputFile.key(), 1, 0)).isEmpty();
     assertThat(logTester.logs()).contains("Skipping Ruby sensor because 'sonar.ruby.internal.skipRubySensor' is enabled.");
   }
 
@@ -139,6 +155,11 @@ class RubySensorTest extends AbstractSensorTest {
 
   private RubySensor sensor(CheckFactory checkFactory) {
     return new RubySensor(SQ_LTS_RUNTIME, checkFactory, fileLinesContextFactory, new DefaultNoSonarFilter(), language());
+  }
+
+  private void setSkipProperty(boolean skip) {
+    context.setSettings(new MapSettings());
+    context.settings().setProperty(RubySensor.SKIP_PROPERTY_KEY, Boolean.toString(skip));
   }
 
 }


### PR DESCRIPTION
## Summary
- default the internal Ruby sensor skip flag to true
- require sonar.ruby.internal.skipRubySensor=false to re-enable RubySensor in scanner/server analysis
- register the property in plugin metadata and update focused unit coverage for the new default

## Testing
- ./gradlew :sonar-ruby-plugin:test --tests org.sonarsource.ruby.plugin.RubySensorTest --tests org.sonarsource.ruby.plugin.RubyPluginTest spotlessCheck

Part of
- N/A