### PR TITLE
(DO NOT MERGE) BUILD-10706: Configure `gh-action_cache` to use S3 cache backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   USE_DEVELOCITY: true
   DEVELOCITY_URL: https://develocity-public.sonar.build/
+  CACHE_BACKEND: s3
 
 jobs:
   build:

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 4 * * *' # Run the workflow every day at 04:00 UTC
   workflow_dispatch:
 
+env:
+  CACHE_BACKEND: s3
+
 jobs:
   unified-platform-dogfooding:
     runs-on: github-ubuntu-latest-s


### PR DESCRIPTION
Use S3 cache backend for CI caching.

Relates to https://sonarsource.atlassian.net/browse/BUILD-10706 (parent ticket - [BUILD-10684](https://sonarsource.atlassian.net/browse/BUILD-10684))

[BUILD-10684]: https://sonarsource.atlassian.net/browse/BUILD-10684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ