### PR TITLE
SONARRUBY-134 Do not run nightly builds on weekends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "45 0 * * *" # Run daily at 0:45 AM UTC
+    - cron: "45 0 * * 1-5" # Run Mon-Fri at 0:45 AM UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -1,7 +1,7 @@
 name: Unified Dogfooding scans
 on:
   schedule:
-    - cron: '0 4 * * *' # Run the workflow every day at 04:00 UTC
+    - cron: '0 4 * * 1-5' # Run the workflow Mon-Fri at 04:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Update cron schedules in GitHub Actions workflows to run Monday to Friday only (1-5), skipping weekends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)