### PR TITLE
SONARRUBY-136 Set up orchestrator cache

### DIFF
--- a/.github/actions/orchestrator-cache/action.yml
+++ b/.github/actions/orchestrator-cache/action.yml
@@ -1,0 +1,32 @@
+name: Setup Orchestrator Cache
+description: Sets up orchestrator cache
+
+inputs:
+  sq-version:
+    description: 'SonarQube version. If DEV, cache will be disabled.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set Orchestrator Cache Variables
+      shell: bash
+      run: |
+        # year-week
+        CACHE_KEY=$(date +'%Y-%U')
+        echo "ORCHESTRATOR_CACHE_KEY=$CACHE_KEY" >> $GITHUB_ENV
+        echo "ORCHESTRATOR_HOME=${{ github.workspace }}/orchestrator" >> $GITHUB_ENV
+
+    - name: Cache Orchestrator
+      if: inputs.sq-version != 'DEV'
+      uses: SonarSource/gh-action_cache@v1
+      with:
+        path: ${{ env.ORCHESTRATOR_HOME }}
+        key: orchestrator-${{ inputs.sq-version }}-${{ env.ORCHESTRATOR_CACHE_KEY }}-${{ github.run_id }}
+        restore-keys: orchestrator-${{ inputs.sq-version }}-${{ env.ORCHESTRATOR_CACHE_KEY }}-
+
+    - name: Setup Orchestrator Home Directory
+      shell: bash
+      run: |
+        mkdir -p "$ORCHESTRATOR_HOME"
+        ls -lRh "$ORCHESTRATOR_HOME"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,10 @@ jobs:
           artifactory-reader-role: private-reader
           use-develocity: ${{ env.USE_DEVELOCITY }}
           develocity-url: ${{ env.DEVELOCITY_URL }}
+      - name: Orchestrator Cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          sq-version: ${{ matrix.item.sq_version }}
       - name: Run QA Tests
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,33 @@
+name: Cleanup S3 Cache
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name (e.g., 'feature/my-branch'). Leave empty to list all entries."
+        required: false
+        type: string
+        default: ""
+      key:
+        description: "Cache key prefix (e.g., 'sccache-Linux-')"
+        required: false
+        type: string
+        default: ""
+      dry-run:
+        description: "Preview deletions without executing them"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  cleanup:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: SonarSource/gh-action_cache/cleanup@v1
+        with:
+          branch: ${{ inputs.branch }}
+          key: ${{ inputs.key }}
+          dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs-public
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: sonar-xs-public
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
- Add orchestrator cache action
- Use the new cache action in the QA job of the build workflow
- Add a cleanup-cache workflow for S3 cache inspection and manual cleanup

Tested: Checked the logs of https://github.com/SonarSource/sonar-ruby/actions/runs/24499072420/job/71601394007 (second run on the PR branch) and verified that sonarqube-enterprise-lw-2026.2.1.121354.zip was found in the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)