### PR TITLE
SONARRUBY-173 Update CODEOWNERS to Language Coverage Squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @SonarSource/quality-jvm-squad
+# https://github.com/orgs/SonarSource/teams/code-quality-language-coverage-squad
+.github/CODEOWNERS @SonarSource/code-quality-language-coverage-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Code ownership updates:**
  - Updated `.github/CODEOWNERS` to assign the repository to the `@SonarSource/code-quality-language-coverage-squad` team.

<sub>This will update automatically on new commits.</sub>