### PR TITLE
Support SimpleCov 1.0.0 JSON formatter reports in SimpleCovSensor

### DIFF
--- a/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/SimpleCovSensor.java
+++ b/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/SimpleCovSensor.java
@@ -89,7 +89,9 @@ public class SimpleCovSensor implements Sensor {
 
     for (Entry<String, Map<Integer, Integer>> coverageForFile : mergedCoverages.entrySet()) {
       String filePath = coverageForFile.getKey();
-      InputFile inputFile = fileSystem.inputFile(predicates.hasAbsolutePath(filePath));
+      // SimpleCov <= 0.22 keyed coverage on absolute paths; 1.0.0 keys it on
+      // project-relative paths. `hasPath` resolves either form.
+      InputFile inputFile = fileSystem.inputFile(predicates.hasPath(filePath));
       if (inputFile != null) {
         try {
           saveNewCoverage(context, coverageForFile.getValue(), inputFile);
@@ -112,12 +114,17 @@ public class SimpleCovSensor implements Sensor {
     newCoverage.save();
   }
 
-  private static void mergeFileCoverages(Map<String, Map<Integer, Integer>> coveragePerFiles, Map<String, JSONObject> upperJsonObjects) {
+  private static void mergeFileCoverages(Map<String, Map<Integer, Integer>> coveragePerFiles, Map<String, Object> upperJsonObjects) {
     upperJsonObjects.forEach((key, value) -> {
-      if ("coverage".equals(key)) {
-        mergeFrameworkCoveragesFromJsonFormatter(coveragePerFiles, value);
+      if (!(value instanceof JSONObject valueObject)) {
+        // The SimpleCov JSON formatter emits scalar top-level entries from
+        // version 1.0.0 on (e.g. "$schema"); they carry no coverage data.
+        return;
       }
-      JSONObject testFrameworkCoverage = (JSONObject) value.get("coverage");
+      if ("coverage".equals(key)) {
+        mergeFrameworkCoveragesFromJsonFormatter(coveragePerFiles, valueObject);
+      }
+      JSONObject testFrameworkCoverage = (JSONObject) valueObject.get("coverage");
       if (testFrameworkCoverage != null) {
         LOG.warn("Importing SimpleCov resultset JSON will not be supported from simplecov 18.0. Consider using the JSON formatter, available from SimpleCov 20.0");
         mergeFrameworkCoveragesFromResultSet(coveragePerFiles, testFrameworkCoverage);

--- a/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/SimpleCovSensorTest.java
+++ b/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/SimpleCovSensorTest.java
@@ -112,6 +112,26 @@ class SimpleCovSensorTest {
   }
 
   @Test
+  void test_reportPath_property_JSON_formatter_1_0() throws IOException {
+    // SimpleCov 1.0.0 adds a scalar top-level "$schema" entry (previously
+    // every top-level value was an object) and keys per-file coverage on
+    // project-relative paths instead of absolute ones.
+    SensorContextTester context = getSensorContext("json_formatter_1_0.json", "file1.rb");
+    sensor.execute(context);
+
+    String fileKey = MODULE_KEY + ":file1.rb";
+    assertThat(context.lineHits(fileKey, 1)).isEqualTo(1);
+    assertThat(context.lineHits(fileKey, 2)).isEqualTo(1);
+    assertThat(context.lineHits(fileKey, 3)).isEqualTo(2);
+    assertThat(context.lineHits(fileKey, 4)).isNull();
+    assertThat(context.lineHits(fileKey, 5)).isNull();
+    assertThat(context.lineHits(fileKey, 6)).isEqualTo(1);
+    assertThat(context.lineHits(fileKey, 7)).isZero();
+
+    assertThat(logTester.logs()).isEmpty();
+  }
+
+  @Test
   void test_absolute_report_path() throws IOException {
     Path baseDir = COVERAGE_DIR.toAbsolutePath();
     Path reportPath = baseDir.resolve("resultset.json");

--- a/sonar-ruby-plugin/src/test/resources/coverage/json_formatter_1_0.json
+++ b/sonar-ruby-plugin/src/test/resources/coverage/json_formatter_1_0.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/simplecov-ruby/simplecov/main/schemas/coverage-v1.0.schema.json",
+  "meta": {
+    "schema_version": "1.0",
+    "simplecov_version": "1.0.0",
+    "command_name": "RSpec",
+    "primary_coverage": "line",
+    "line_coverage": true,
+    "branch_coverage": false,
+    "method_coverage": false
+  },
+  "total": {
+    "lines": {
+      "covered": 4,
+      "missed": 1,
+      "omitted": 2,
+      "total": 5,
+      "percent": 80.0
+    }
+  },
+  "coverage": {
+    "file1.rb": {
+      "lines": [
+        1,
+        1,
+        2,
+        null,
+        "ignored",
+        1,
+        0
+      ],
+      "branches": [
+      ]
+    }
+  },
+  "groups": {},
+  "errors": {}
+}


### PR DESCRIPTION
SimpleCov 1.0.0 (released days ago, on July 12, 2026) changed its JSON formatter output in two ways that `SimpleCovSensor` cannot handle, so coverage import fails for anyone on the new version. (Reported downstream at https://github.com/simplecov-ruby/simplecov/issues/1228 with SonarQube Community Server 25.12.)

There are two problems:

1. **A scalar top-level entry fails the whole report.** To keep supporting the legacy `.resultset.json` shape, `mergeFileCoverages` probes every top-level value in the report as a `JSONObject`. SimpleCov 1.0.0 adds a top-level `"$schema"` entry whose value is a string (the URL of the JSON schema the document conforms to), so the probe throws and the report is rejected:

```
ERROR Cannot read coverage report file, expecting standard SimpleCov JSON formatter output: 'coverage/coverage.json'
java.lang.ClassCastException: class java.lang.String cannot be cast to class org.sonarsource.analyzer.commons.internal.json.simple.JSONObject
```

2. **Relative file keys resolve to nothing.** SimpleCov 1.0.0 keys per-file coverage on project-relative paths (`lib/foo.rb`) where earlier versions used absolute paths. `saveCoverage` looks files up with `predicates.hasAbsolutePath`, so even with the parse fixed, every file would log "cannot be found in filesystem" and no coverage would be saved.

This patch addresses these problems:
- `mergeFileCoverages` skips top-level values that are not JSON objects. Scalar entries carry no coverage data in any SimpleCov format.
- `saveCoverage` resolves file keys with `predicates.hasPath`, which accepts absolute and relative forms. This is the same predicate the sensor already uses to locate the report file itself.

I’ve also added a `json_formatter_1_0.json` fixture with the real 1.0.0 shape (top-level `$schema`, expanded `meta`, `total` section, relative file keys) and a test asserting line hits import with no warnings or errors logged. Existing tests are untouched, and the existing fixtures still pass, so resultset imports and 0.22-style JSON formatter reports with absolute keys will keep working just as they do now.