### PR TITLE
RUBY-182 Update rule metadata

### DIFF
--- a/sonar-ruby-plugin/sonarpedia.json
+++ b/sonar-ruby-plugin/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "RUBY"
   ],
-  "latest-update": "2026-06-22T12:41:45.761227575Z",
+  "latest-update": "2026-07-15T14:35:51.579106Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true

--- a/sonar-ruby-plugin/src/main/resources/org/sonar/l10n/ruby/rules/ruby/S1313.html
+++ b/sonar-ruby-plugin/src/main/resources/org/sonar/l10n/ruby/rules/ruby/S1313.html
@@ -43,6 +43,7 @@ ip = IP_ADDRESS
 <h2>Resources</h2>
 <h3>Standards</h3>
 <ul>
+  <li>CWE - <a href="https://cwe.mitre.org/data/definitions/547">CWE-547 - Use of Hard-coded, Security-relevant Constants</a></li>
   <li>OWASP - <a href="https://owasp.org/Top10/A01_2021-Broken_Access_Control/">Top 10 2021 Category A1 - Broken Access Control</a></li>
   <li>OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure">Top 10 2017 Category A3 - Sensitive Data
   Exposure</a></li>

--- a/sonar-ruby-plugin/src/main/resources/org/sonar/l10n/ruby/rules/ruby/S2068.json
+++ b/sonar-ruby-plugin/src/main/resources/org/sonar/l10n/ruby/rules/ruby/S2068.json
@@ -15,7 +15,8 @@
   "quickfix": "infeasible",
   "tags": [
     "cwe",
-    "former-hotspot"
+    "former-hotspot",
+    "secret"
   ],
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-2068",


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule metadata:**
  - Added `secret` tag to `S2068` rule definition.
  - Included `CWE-547` reference in `S1313` rule documentation.
- **Maintenance:**
  - Updated `latest-update` timestamp in `sonarpedia.json` to July 2026.

<sub>This will update automatically on new commits.</sub>