### PR TITLE
RUBY-188 Support SimpleCov 1.0.0 JSON formatter reports in SimpleCovSensor

### DIFF
--- a/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/SimpleCovSensor.java
+++ b/sonar-ruby-plugin/src/main/java/org/sonarsource/ruby/plugin/SimpleCovSensor.java
@@ -89,7 +89,9 @@ public class SimpleCovSensor implements Sensor {
 
     for (Entry<String, Map<Integer, Integer>> coverageForFile : mergedCoverages.entrySet()) {
       String filePath = coverageForFile.getKey();
-      InputFile inputFile = fileSystem.inputFile(predicates.hasAbsolutePath(filePath));
+      // SimpleCov <= 0.22 keyed coverage on absolute paths; 1.0.0 keys it on
+      // project-relative paths. `hasPath` resolves either form.
+      InputFile inputFile = fileSystem.inputFile(predicates.hasPath(filePath));
       if (inputFile != null) {
         try {
           saveNewCoverage(context, coverageForFile.getValue(), inputFile);
@@ -112,12 +114,17 @@ public class SimpleCovSensor implements Sensor {
     newCoverage.save();
   }
 
-  private static void mergeFileCoverages(Map<String, Map<Integer, Integer>> coveragePerFiles, Map<String, JSONObject> upperJsonObjects) {
+  private static void mergeFileCoverages(Map<String, Map<Integer, Integer>> coveragePerFiles, Map<String, Object> upperJsonObjects) {
     upperJsonObjects.forEach((key, value) -> {
-      if ("coverage".equals(key)) {
-        mergeFrameworkCoveragesFromJsonFormatter(coveragePerFiles, value);
+      if (!(value instanceof JSONObject valueObject)) {
+        // The SimpleCov JSON formatter emits scalar top-level entries from
+        // version 1.0.0 on (e.g. "$schema"); they carry no coverage data.
+        return;
       }
-      JSONObject testFrameworkCoverage = (JSONObject) value.get("coverage");
+      if ("coverage".equals(key)) {
+        mergeFrameworkCoveragesFromJsonFormatter(coveragePerFiles, valueObject);
+      }
+      JSONObject testFrameworkCoverage = (JSONObject) valueObject.get("coverage");
       if (testFrameworkCoverage != null) {
         LOG.warn("Importing SimpleCov resultset JSON will not be supported from simplecov 18.0. Consider using the JSON formatter, available from SimpleCov 20.0");
         mergeFrameworkCoveragesFromResultSet(coveragePerFiles, testFrameworkCoverage);

--- a/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/SimpleCovSensorTest.java
+++ b/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/SimpleCovSensorTest.java
@@ -112,6 +112,26 @@ class SimpleCovSensorTest {
   }
 
   @Test
+  void test_reportPath_property_JSON_formatter_1_0() throws IOException {
+    // SimpleCov 1.0.0 adds a scalar top-level "$schema" entry (previously
+    // every top-level value was an object) and keys per-file coverage on
+    // project-relative paths instead of absolute ones.
+    SensorContextTester context = getSensorContext("json_formatter_1_0.json", "file1.rb");
+    sensor.execute(context);
+
+    String fileKey = MODULE_KEY + ":file1.rb";
+    assertThat(context.lineHits(fileKey, 1)).isEqualTo(1);
+    assertThat(context.lineHits(fileKey, 2)).isEqualTo(1);
+    assertThat(context.lineHits(fileKey, 3)).isEqualTo(2);
+    assertThat(context.lineHits(fileKey, 4)).isNull();
+    assertThat(context.lineHits(fileKey, 5)).isNull();
+    assertThat(context.lineHits(fileKey, 6)).isEqualTo(1);
+    assertThat(context.lineHits(fileKey, 7)).isZero();
+
+    assertThat(logTester.logs()).isEmpty();
+  }
+
+  @Test
   void test_absolute_report_path() throws IOException {
     Path baseDir = COVERAGE_DIR.toAbsolutePath();
     Path reportPath = baseDir.resolve("resultset.json");

--- a/sonar-ruby-plugin/src/test/resources/coverage/json_formatter_1_0.json
+++ b/sonar-ruby-plugin/src/test/resources/coverage/json_formatter_1_0.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/simplecov-ruby/simplecov/main/schemas/coverage-v1.0.schema.json",
+  "meta": {
+    "schema_version": "1.0",
+    "simplecov_version": "1.0.0",
+    "command_name": "RSpec",
+    "primary_coverage": "line",
+    "line_coverage": true,
+    "branch_coverage": false,
+    "method_coverage": false
+  },
+  "total": {
+    "lines": {
+      "covered": 4,
+      "missed": 1,
+      "omitted": 2,
+      "total": 5,
+      "percent": 80.0
+    }
+  },
+  "coverage": {
+    "file1.rb": {
+      "lines": [
+        1,
+        1,
+        2,
+        null,
+        "ignored",
+        1,
+        0
+      ],
+      "branches": [
+      ]
+    }
+  },
+  "groups": {},
+  "errors": {}
+}


### PR DESCRIPTION
SimpleCov 1.0.0 made two changes to the JSON formatter output that the
sensor could not handle. The report gained a scalar top-level
'$schema' entry, which mergeFileCoverages cast to JSONObject while
probing every top-level value for the legacy resultset shape, failing
the whole report with ClassCastException. And per-file coverage is now
keyed on project-relative paths instead of absolute paths, so file
lookup via hasAbsolutePath would find nothing even after a successful
parse.

Skip non-object top-level values when merging, and resolve report file
keys with hasPath, which accepts both absolute and relative forms, so
reports from SimpleCov 0.18 through 1.0.0 all import.
